### PR TITLE
feat: create default user preferences when materializing users

### DIFF
--- a/apps/migrations/src/migrations/0002_hesitant_lucky_pierre.sql
+++ b/apps/migrations/src/migrations/0002_hesitant_lucky_pierre.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "preferences" ADD CONSTRAINT "preferences_user_id_unique" UNIQUE("user_id");

--- a/apps/migrations/src/migrations/meta/0002_snapshot.json
+++ b/apps/migrations/src/migrations/meta/0002_snapshot.json
@@ -1,0 +1,151 @@
+{
+  "id": "239b8cdf-d3fc-406e-af9f-ddc9aa68808f",
+  "prevId": "f96b14c4-0340-4bd7-b0bc-df3ce1a1bc56",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.preferences": {
+      "name": "preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "frequency_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'daily'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "preferences_user_id_users_id_fk": {
+          "name": "preferences_user_id_users_id_fk",
+          "tableFrom": "preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "preferences_user_id_unique": {
+          "name": "preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.frequency_type": {
+      "name": "frequency_type",
+      "schema": "public",
+      "values": [
+        "daily",
+        "paused"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/migrations/src/migrations/meta/_journal.json
+++ b/apps/migrations/src/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1755795100604,
       "tag": "0001_slimy_unicorn",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1755850440683,
+      "tag": "0002_hesitant_lucky_pierre",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/schema/preferences.ts
+++ b/packages/database/schema/preferences.ts
@@ -9,7 +9,8 @@ export const preferences = pgTable('preferences', {
   id: uuid('id').primaryKey().defaultRandom(),
   userId: varchar('user_id')
     .references(() => users.id, { onDelete: 'cascade' })
-    .notNull(),
+    .notNull()
+    .unique(),
   frequency: frequencyType('frequency').default('daily'),
   createdAt: timestamp({
     withTimezone: true,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

# Proposed changes

<!-- Describe the changes here giving as much context as necessary -->

This pull request introduces the creation and enforcement of a unique user preference record for each user, both at the database schema and application logic levels. It ensures that a `preferences` entry is created whenever a new user is added, and adds error handling to respond appropriately if user or preference creation fails. Additionally, it updates the database schema and migration metadata to reflect these changes.

**Database schema and migration changes:**

* Added a unique constraint on the `user_id` column in the `preferences` table to ensure each user can have only one preference record (`apps/migrations/src/migrations/0002_hesitant_lucky_pierre.sql`, `packages/database/schema/preferences.ts`, `apps/migrations/src/migrations/meta/0002_snapshot.json`) [[1]](diffhunk://#diff-00b219d23a2fab3d690b875ff3ade98eb56f1de52740500cb62bf8b0b7b546caR1) [[2]](diffhunk://#diff-60269cfc1695a286376c38a5d411574da478bc55376c5582f1c2994fe9d09d5eL12-R13) [[3]](diffhunk://#diff-db397a83ba48a61c617aeae5d5b9cb29e361b156c8b753d68113bdd579e85329R1-R151).
* Updated migration metadata to include the new migration and schema snapshot (`apps/migrations/src/migrations/meta/_journal.json`, `apps/migrations/src/migrations/meta/0002_snapshot.json`) [[1]](diffhunk://#diff-39171439a913acff5481c250c6369f93f91f8572ef4b1bed1692a6f0828fee8cR18-R24) [[2]](diffhunk://#diff-db397a83ba48a61c617aeae5d5b9cb29e361b156c8b753d68113bdd579e85329R1-R151).

## Related links

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Related issue #5
- Closes #

## Definition of Done

<!-- Strikethrough any below that are not applicable. -->

**Always:**

- [x] All Acceptance Criteria have been met <!-- (if not, specify what's left via TODOs)  -->
- [x] Test successfully locally
- [ ] Increase or maintain coverage
