### PR TITLE
feat: added ability to change phone numbers

### DIFF
--- a/apps/app/src/app/api/common/profile/route.ts
+++ b/apps/app/src/app/api/common/profile/route.ts
@@ -1,0 +1,79 @@
+import { createConnection } from '@internal/database/connection'
+import { env } from '@/env'
+import { auth } from '@clerk/nextjs/server'
+import { NextResponse } from 'next/server'
+import { users } from '@internal/database/schema'
+import { eq } from 'drizzle-orm'
+import { UpdateProfileBodySchema } from '@/features/account-profile'
+import type { PgUpdateSetSource } from 'drizzle-orm/pg-core'
+
+const connection = createConnection(env.DATABASE_URL)
+
+export async function GET() {
+  const { userId } = await auth()
+
+  if (!userId) {
+    return NextResponse.json(
+      {
+        code: 'not_authorized',
+        statusCode: 401,
+      },
+      {
+        status: 401,
+      }
+    )
+  }
+
+  const [user] = await connection
+    .select()
+    .from(users)
+    .where(eq(users.id, userId))
+
+  return NextResponse.json(
+    {
+      phoneNumber: user.phoneNumber,
+    },
+    { status: 200 }
+  )
+}
+
+export async function PUT(request: Request) {
+  const { userId } = await auth()
+
+  if (!userId) {
+    return NextResponse.json(
+      {
+        code: 'not_authorized',
+        statusCode: 401,
+      },
+      {
+        status: 401,
+      }
+    )
+  }
+
+  const body = UpdateProfileBodySchema.safeParse(await request.json())
+
+  if (!body.success) {
+    return NextResponse.json(
+      {
+        code: 'invalid_request',
+        statusCode: 400,
+      },
+      { status: 400 }
+    )
+  }
+
+  const set: PgUpdateSetSource<typeof users> = {
+    phoneNumber: body.data.phoneNumber,
+  }
+
+  await connection.update(users).set(set).where(eq(users.id, userId))
+
+  return NextResponse.json(
+    {
+      phoneNumber: body.data.phoneNumber,
+    },
+    { status: 200 }
+  )
+}

--- a/apps/app/src/features/account-profile/api/get.ts
+++ b/apps/app/src/features/account-profile/api/get.ts
@@ -1,0 +1,13 @@
+import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
+
+export const ProfileSchema = z.object({
+  phoneNumber: z.string().nullable(),
+})
+
+export type Profile = z.infer<typeof ProfileSchema>
+
+export const getProfileOptions = queryOptions<Profile>({
+  queryKey: ['profile'],
+  queryFn: () => fetch('/api/common/profile').then((res) => res.json()),
+})

--- a/apps/app/src/features/account-profile/api/index.ts
+++ b/apps/app/src/features/account-profile/api/index.ts
@@ -1,0 +1,2 @@
+export * from './get'
+export * from './update'

--- a/apps/app/src/features/account-profile/api/update.ts
+++ b/apps/app/src/features/account-profile/api/update.ts
@@ -2,37 +2,34 @@ import type { MutationConfig } from '@/lib/react-query'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { z } from 'zod'
 
-export const UpdatePreferenceBodySchema = z.object({
-  goals: z.array(z.string()).min(1),
-  themes: z.array(z.string()).min(1),
+export const UpdateProfileBodySchema = z.object({
+  phoneNumber: z.string().min(10).max(15).optional(),
 })
 
-export type UpdatePreferenceBody = z.infer<typeof UpdatePreferenceBodySchema>
+export type UpdateProfileBody = z.infer<typeof UpdateProfileBodySchema>
 
-type UseUpdatePreferencesOptions = {
+type UseUpdateProfileOptions = {
   mutationConfig?: MutationConfig<
-    (
-      body: UpdatePreferenceBody
-    ) => Promise<{ error?: string; success: boolean }>
+    (body: UpdateProfileBody) => Promise<{ error?: string; success: boolean }>
   >
 }
 
-export const useUpdatePreferences = ({
+export const useUpdateProfile = ({
   mutationConfig,
-}: UseUpdatePreferencesOptions) => {
+}: UseUpdateProfileOptions) => {
   const queryClient = useQueryClient()
 
   const { onSuccess, ...restConfig } = mutationConfig ?? {}
 
   return useMutation({
     onSuccess: async (...args) => {
-      await queryClient.invalidateQueries({ queryKey: ['preferences'] })
+      await queryClient.invalidateQueries({ queryKey: ['profile'] })
 
       onSuccess?.(...args)
     },
     ...restConfig,
-    mutationFn: async (body: UpdatePreferenceBody) => {
-      const response = await fetch('/api/common/preferences', {
+    mutationFn: async (body: UpdateProfileBody) => {
+      const response = await fetch('/api/common/profile', {
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',
@@ -43,7 +40,7 @@ export const useUpdatePreferences = ({
 
       if (!response.ok) {
         return {
-          error: 'Failed to update preferences',
+          error: 'Failed to update profile',
           success: false,
         }
       }

--- a/apps/app/src/features/account-profile/index.ts
+++ b/apps/app/src/features/account-profile/index.ts
@@ -1,1 +1,2 @@
+export * from './api'
 export * from './templates'

--- a/apps/app/src/features/account-profile/templates/AccountProfilePageTemplate.tsx
+++ b/apps/app/src/features/account-profile/templates/AccountProfilePageTemplate.tsx
@@ -2,11 +2,23 @@
 
 import { useUser } from '@clerk/nextjs'
 import { ChangePhoneNumber, Name } from '../components'
+import { useQueries } from '@tanstack/react-query'
+import { queryConfig } from '@/lib/react-query'
+import { getProfileOptions } from '../api'
 
 export const AccountProfilePageTemplate = () => {
   const { isLoaded, user } = useUser()
 
-  if (!isLoaded) {
+  const [profileQuery] = useQueries({
+    queries: [
+      {
+        ...getProfileOptions,
+        ...queryConfig,
+      },
+    ],
+  })
+
+  if (!isLoaded || profileQuery.isLoading) {
     return <div>Loading...</div>
   }
 
@@ -29,7 +41,7 @@ export const AccountProfilePageTemplate = () => {
       <ChangePhoneNumber
         defaultCountry="ES"
         defaultValues={{
-          phoneNumber: '',
+          phoneNumber: profileQuery.data?.phoneNumber ?? '',
         }}
       />
     </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

# Proposed changes

<!-- Describe the changes here giving as much context as necessary -->

This pull request adds backend and frontend support for updating and displaying a user's phone number in their account profile. It introduces a new API route for profile management, integrates React Query for data fetching and mutation, and refactors the phone number change flow to use the new API instead of direct Clerk interactions.

**Backend: Profile API implementation**
- Added a new API route `apps/app/src/app/api/common/profile/route.ts` with `GET` and `PUT` handlers for retrieving and updating the user's phone number, including input validation and authentication checks.

**Frontend: Data fetching and mutation**
- Introduced React Query hooks and schemas for profile data:
  - Created `getProfileOptions` and `ProfileSchema` in `api/get.ts` for fetching the user's phone number.
  - Added `useUpdateProfile` mutation hook and schema in `api/update.ts` for updating the phone number via the new API.
  - Exported these API utilities via `api/index.ts` and `index.ts` for use throughout the feature. [[1]](diffhunk://#diff-aa1cc751ac2e56c3e84b2391b4631b9d0240b17c9763ad5f9a824d328472c82aR1-R2) [[2]](diffhunk://#diff-9e8214a5a98da4f6ae4822a382892cc7bcbbf3d6d0ced531ca73cfe58d827fa0R1)

**Frontend: Profile page and phone number change flow**
- Updated `AccountProfilePageTemplate` to use React Query's `useQueries` and the new API for loading the user's phone number, and to pass the fetched value as the default to the phone number change form. [[1]](diffhunk://#diff-2c84071da6b9f7ef5113299477bf2b5f1a3d2f0f31ce49e47fbc6b25ecc1282eR5-R21) [[2]](diffhunk://#diff-2c84071da6b9f7ef5113299477bf2b5f1a3d2f0f31ce49e47fbc6b25ecc1282eL32-R44)
- Refactored `ChangePhoneNumber` component to use the new `useUpdateProfile` mutation instead of direct Clerk API calls, simplifying the logic and error handling. [[1]](diffhunk://#diff-3bb4a405d888f9b6da6b24f0651c32b755595e8c28436adf826b9958eb98dd57L21-R24) [[2]](diffhunk://#diff-3bb4a405d888f9b6da6b24f0651c32b755595e8c28436adf826b9958eb98dd57L38-R64) [[3]](diffhunk://#diff-3bb4a405d888f9b6da6b24f0651c32b755595e8c28436adf826b9958eb98dd57L114-R96)

**Other improvements**
- Fixed a minor type naming issue in the dashboard preferences API (`UseUpdateOptions` → `UseUpdatePreferencesOptions`).

## Related links

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Related issue #5
- Closes #8

## Definition of Done

<!-- Strikethrough any below that are not applicable. -->

**Always:**

- [x] All Acceptance Criteria have been met <!-- (if not, specify what's left via TODOs)  -->
- [x] Test successfully locally
- [ ] Increase or maintain coverage
