### PR TITLE
feat: added the ability to manage frequency of receiving messages

### DIFF
--- a/apps/app/src/features/dashboard/api/get.ts
+++ b/apps/app/src/features/dashboard/api/get.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 export const PreferencesSchema = z.object({
   goals: z.array(z.string()),
   themes: z.array(z.string()),
+  frequency: z.enum(['daily', 'paused']),
 })
 
 export type Preferences = z.infer<typeof PreferencesSchema>

--- a/apps/app/src/features/dashboard/api/update.ts
+++ b/apps/app/src/features/dashboard/api/update.ts
@@ -2,10 +2,13 @@ import type { MutationConfig } from '@/lib/react-query'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { z } from 'zod'
 
-export const UpdatePreferenceBodySchema = z.object({
-  goals: z.array(z.string()).min(1),
-  themes: z.array(z.string()).min(1),
-})
+export const UpdatePreferenceBodySchema = z
+  .object({
+    goals: z.array(z.string()).min(1),
+    themes: z.array(z.string()).min(1),
+    frequency: z.enum(['daily', 'paused']),
+  })
+  .partial()
 
 export type UpdatePreferenceBody = z.infer<typeof UpdatePreferenceBodySchema>
 

--- a/apps/app/src/features/dashboard/components/ManageFrequency.tsx
+++ b/apps/app/src/features/dashboard/components/ManageFrequency.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@internal/design-system/components/ui/card'
+import { useZodForm } from '@/lib/use-zod-form'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@internal/design-system/components/ui/form'
+import { PreferencesSchema } from '../api'
+import { useUpdatePreferences } from '../api'
+import { useAutoSave } from '@/lib/use-auto-save'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@internal/design-system/components/ui/select'
+import type { z } from 'zod'
+
+const defaultFrequency = 'daily'
+
+const FormSchema = PreferencesSchema.omit({
+  goals: true,
+  themes: true,
+})
+
+interface Props {
+  preference: z.infer<typeof FormSchema>
+}
+
+export const ManageFrequency = (props: Props) => {
+  const form = useZodForm(FormSchema, {
+    defaultValues: {
+      frequency: props.preference.frequency ?? defaultFrequency,
+    },
+  })
+
+  const updatePreferences = useUpdatePreferences({
+    mutationConfig: {
+      onSuccess: () => {
+        // Optionally show a success message or perform other actions
+      },
+    },
+  })
+
+  useAutoSave({
+    defaultValues: {
+      frequency: props.preference.frequency ?? defaultFrequency,
+    },
+    form,
+    onSubmit: (data) => {
+      updatePreferences.mutate(data)
+    },
+  })
+
+  return (
+    <Form {...form}>
+      <Card>
+        <CardHeader>
+          <CardTitle>Manage Frequency</CardTitle>
+          <CardDescription>
+            Determine how often you want to receive motivational messages.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <FormField
+            control={form.control}
+            name="frequency"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Message Frequency</FormLabel>
+                <FormControl>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="w-32">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="daily">Daily</SelectItem>
+                      <SelectItem value="paused">Paused</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </CardContent>
+      </Card>
+    </Form>
+  )
+}

--- a/apps/app/src/features/dashboard/components/ManageGoalsAndDirection.tsx
+++ b/apps/app/src/features/dashboard/components/ManageGoalsAndDirection.tsx
@@ -17,9 +17,10 @@ import {
 } from '@internal/design-system/components/ui/form'
 import { Badge } from '@internal/design-system/components/ui/badge'
 import { XIcon } from 'lucide-react'
-import type { Preferences } from '../api'
-import { UpdatePreferenceBodySchema, useUpdatePreferences } from '../api'
+import { PreferencesSchema } from '../api'
+import { useUpdatePreferences } from '../api'
 import { useAutoSave } from '@/lib/use-auto-save'
+import type { z } from 'zod'
 
 const commonThemes = [
   'Fitness & Health',
@@ -47,12 +48,16 @@ const commonGoals = [
   'Eat healthier',
 ]
 
+const FormSchema = PreferencesSchema.omit({
+  frequency: true,
+})
+
 interface Props {
-  preference: Preferences
+  preference: z.infer<typeof FormSchema>
 }
 
 export const ManageGoalsAndDirection = (props: Props) => {
-  const form = useZodForm(UpdatePreferenceBodySchema, {
+  const form = useZodForm(FormSchema, {
     defaultValues: {
       goals: props.preference.goals,
       themes: props.preference.themes,
@@ -84,7 +89,7 @@ export const ManageGoalsAndDirection = (props: Props) => {
         <CardHeader>
           <CardTitle>Manage Goals and Direction</CardTitle>
           <CardDescription>
-            Define your personal goals and motivational themes
+            Define your personal goals and motivational themes.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">

--- a/apps/app/src/features/dashboard/components/index.ts
+++ b/apps/app/src/features/dashboard/components/index.ts
@@ -1,1 +1,2 @@
+export * from './ManageFrequency'
 export * from './ManageGoalsAndDirection'

--- a/apps/app/src/features/dashboard/templates/DashboardPageTemplate.tsx
+++ b/apps/app/src/features/dashboard/templates/DashboardPageTemplate.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ManageGoalsAndDirection } from '../components'
+import { ManageFrequency, ManageGoalsAndDirection } from '../components'
 import { useQueries } from '@tanstack/react-query'
 import { getPreferencesOptions } from '@/features/dashboard'
 import { queryConfig } from '@/lib/react-query'
@@ -30,25 +30,32 @@ export const DashboardPageTemplate = () => {
       {preferencesQuery.isLoading ? (
         <div>Loading...</div>
       ) : (
-        <ManageGoalsAndDirection
-          preference={
-            preferencesQuery.data
-              ? {
-                  goals:
-                    preferencesQuery.data.goals.length > 0
-                      ? preferencesQuery.data.goals
-                      : defaultGoals,
-                  themes:
-                    preferencesQuery.data.themes.length > 0
-                      ? preferencesQuery.data.themes
-                      : defaultThemes,
-                }
-              : {
-                  goals: defaultGoals,
-                  themes: defaultThemes,
-                }
-          }
-        />
+        <>
+          <ManageGoalsAndDirection
+            preference={
+              preferencesQuery.data
+                ? {
+                    goals:
+                      preferencesQuery.data.goals.length > 0
+                        ? preferencesQuery.data.goals
+                        : defaultGoals,
+                    themes:
+                      preferencesQuery.data.themes.length > 0
+                        ? preferencesQuery.data.themes
+                        : defaultThemes,
+                  }
+                : {
+                    goals: defaultGoals,
+                    themes: defaultThemes,
+                  }
+            }
+          />
+          <ManageFrequency
+            preference={{
+              frequency: preferencesQuery.data?.frequency ?? 'daily',
+            }}
+          />
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

# Proposed changes

<!-- Describe the changes here giving as much context as necessary -->

This pull request introduces support for managing the "frequency" preference (how often motivational messages are sent) throughout the dashboard application. The changes include backend API updates, schema validation, UI components, and integration into the dashboard page.

**Backend and API updates:**

- Added `frequency` to the preferences API, including support for reading and updating this value in the database, and returning it in API responses. [[1]](diffhunk://#diff-88429616d77a980cb33a4fabae8f4dac6b5d2d414e9e4616f6133899c5fd1ab7R40) [[2]](diffhunk://#diff-88429616d77a980cb33a4fabae8f4dac6b5d2d414e9e4616f6133899c5fd1ab7R50) [[3]](diffhunk://#diff-88429616d77a980cb33a4fabae8f4dac6b5d2d414e9e4616f6133899c5fd1ab7R83-R119)
- Updated the backend validation schema to include `frequency`, supporting values `'daily'` and `'paused'`. [[1]](diffhunk://#diff-ee36d95d69e8f263722037d3c68a1e7965000a529b9d93c5f4b032bb913a0869R7) [[2]](diffhunk://#diff-5a389b2c0dd06c434928ee0a58587f0332a6c91efe345b278f3411f9ccab7700L5-R11)

**Frontend and UI updates:**

- Added a new `ManageFrequency` component for users to manage their message frequency preference, including a select input for "Daily" or "Paused". [[1]](diffhunk://#diff-d014f7f45bb0ad625999ec5744c2379642670c37af83b7cf3b0069d2a0266b76R1-R100) [[2]](diffhunk://#diff-e9b51f05096073517c8e3ac12315c8ac6fd5187aaf97f51e64a8ccbf62d1ea2eR1)
- Updated `ManageGoalsAndDirection` and related form logic to separate out the `frequency` field, ensuring forms only handle relevant fields. [[1]](diffhunk://#diff-24ca74629137f486e35e5746bb4afb0dfbb3504aa6ffa73c2fe69f265b852a15L20-R23) [[2]](diffhunk://#diff-24ca74629137f486e35e5746bb4afb0dfbb3504aa6ffa73c2fe69f265b852a15R51-R60) [[3]](diffhunk://#diff-24ca74629137f486e35e5746bb4afb0dfbb3504aa6ffa73c2fe69f265b852a15L87-R92)
- Integrated the new `ManageFrequency` component into the dashboard page template so users can update their frequency preference alongside their goals and themes. [[1]](diffhunk://#diff-1e4566a94db1660bb28e6d9a7433c3f11b26552184edf6fc7a7131015cc64fb3L3-R3) [[2]](diffhunk://#diff-1e4566a94db1660bb28e6d9a7433c3f11b26552184edf6fc7a7131015cc64fb3R33) [[3]](diffhunk://#diff-1e4566a94db1660bb28e6d9a7433c3f11b26552184edf6fc7a7131015cc64fb3R53-R58)

## Related links

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Related issue #5
- Closes #

## Definition of Done

<!-- Strikethrough any below that are not applicable. -->

**Always:**

- [x] All Acceptance Criteria have been met <!-- (if not, specify what's left via TODOs)  -->
- [x] Test successfully locally
- [ ] Increase or maintain coverage
