### PR TITLE
feat: added onboarding for users to gather their goals and phone number

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -41,6 +41,7 @@ jobs:
     env:
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY }}
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
       - uses: actions/checkout@v4

--- a/apps/app/src/app/(authenticated)/(default)/layout.tsx
+++ b/apps/app/src/app/(authenticated)/(default)/layout.tsx
@@ -5,12 +5,16 @@ import {
 } from '@internal/design-system/components/ui/sidebar'
 import { HotKeys } from '@/features/hot-keys'
 import { AppHeader } from '@/features/app-header'
+import { UserOnboardingDialog } from '@/features/dashboard'
+import { auth } from '@clerk/nextjs/server'
 
 export default async function Layout({
   children,
 }: Readonly<{
   children: ReactNode
 }>) {
+  const { sessionClaims } = await auth()
+
   return (
     <>
       <SidebarProvider>
@@ -26,6 +30,9 @@ export default async function Layout({
         </SidebarInset>
       </SidebarProvider>
       <HotKeys />
+      <UserOnboardingDialog
+        onboardingCompleted={sessionClaims?.metadata.onboardingCompleted}
+      />
     </>
   )
 }

--- a/apps/app/src/features/dashboard/api/update.ts
+++ b/apps/app/src/features/dashboard/api/update.ts
@@ -1,7 +1,6 @@
 import type { MutationConfig } from '@/lib/react-query'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { z } from 'zod'
-import { revalidateTag } from 'next/cache'
 
 export const UpdatePreferenceBodySchema = z
   .object({

--- a/apps/app/src/features/dashboard/components/CompleteOnboardingDialogStep.tsx
+++ b/apps/app/src/features/dashboard/components/CompleteOnboardingDialogStep.tsx
@@ -1,0 +1,56 @@
+import {
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@internal/design-system/components/ui/dialog'
+import { Button } from '@internal/design-system/components/ui/button'
+import { useCallback, useTransition } from 'react'
+import { useUser } from '@clerk/nextjs'
+import type { UserOnboardingDialogStepProps } from './UserOnboardingDialog'
+
+export const CompleteOnboardingDialogStep = (
+  props: UserOnboardingDialogStepProps
+) => {
+  const { isLoaded, user } = useUser()
+
+  const [isPending, startTransition] = useTransition()
+
+  const onConfirm = useCallback(() => {
+    if (!isLoaded) {
+      return
+    }
+
+    startTransition(async () => {
+      await user?.update({
+        unsafeMetadata: { onboardingCompleted: true },
+      })
+
+      await user?.reload()
+
+      props.setCurrentStep(null)
+    })
+  }, [isLoaded, props, user])
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Onboarding Completed</DialogTitle>
+      </DialogHeader>
+      <div className="space-y-6">
+        <p>
+          Congratulations! Your account is now fully configured and ready to
+          inspire you.
+        </p>
+        <p>
+          You&#39;ll start receiving personalized motivational messages based on
+          your goals and themes tomorrow!
+        </p>
+      </div>
+      <DialogFooter>
+        <Button loading={isPending} onClick={onConfirm} type="submit">
+          Complete
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}

--- a/apps/app/src/features/dashboard/components/PhoneNumberDialogStep.tsx
+++ b/apps/app/src/features/dashboard/components/PhoneNumberDialogStep.tsx
@@ -1,0 +1,100 @@
+import { useZodForm } from '@/lib/use-zod-form'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@internal/design-system/components/ui/form'
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@internal/design-system/components/ui/dialog'
+import { Button } from '@internal/design-system/components/ui/button'
+import { z } from 'zod'
+import type { UserOnboardingDialogStepProps } from './UserOnboardingDialog'
+import { useUpdateProfile } from '@/features/account-profile'
+import { toast } from 'sonner'
+import { PhoneInput } from '@internal/design-system/components/ui/phone-input'
+import type { Country } from 'react-phone-number-input'
+
+const FormSchema = z.object({
+  phoneNumber: z.string().min(1),
+})
+
+type Props = UserOnboardingDialogStepProps & {
+  defaultCountry: Country
+}
+
+export const PhoneNumberDialogStep = (props: Props) => {
+  const form = useZodForm(FormSchema, {
+    defaultValues: {
+      phoneNumber: '',
+    },
+  })
+
+  const updateProfile = useUpdateProfile({
+    mutationConfig: {
+      onSuccess: () => {
+        //
+      },
+    },
+  })
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    const result = await updateProfile.mutateAsync(values)
+
+    if (!result) {
+      toast.error('Failed to update phone number. Please try again.')
+
+      return
+    }
+
+    props.setCurrentStep('complete')
+  })
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Step 2: Phone Number</DialogTitle>
+        <DialogDescription>
+          Where should we send your motivational messages?
+        </DialogDescription>
+      </DialogHeader>
+      <Form {...form}>
+        <form onSubmit={onSubmit} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="phoneNumber"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Phone Number</FormLabel>
+                <FormControl>
+                  <PhoneInput
+                    defaultCountry={props.defaultCountry}
+                    international
+                    {...field}
+                    autoComplete="off"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <DialogFooter>
+            <Button
+              loading={updateProfile.isPending}
+              disabled={!form.formState.isValid}
+              type="submit"
+            >
+              Next
+            </Button>
+          </DialogFooter>
+        </form>
+      </Form>
+    </>
+  )
+}

--- a/apps/app/src/features/dashboard/components/PreviewMessage.tsx
+++ b/apps/app/src/features/dashboard/components/PreviewMessage.tsx
@@ -1,4 +1,4 @@
-import type { Preview as PreviewMessage } from '../api'
+import type { Preview } from '../api'
 import {
   Card,
   CardDescription,
@@ -10,10 +10,10 @@ import {
 import { ClockIcon } from 'lucide-react'
 
 interface Props {
-  preview: PreviewMessage
+  preview: Preview
 }
 
-export const Preview = (props: Props) => {
+export const PreviewMessage = (props: Props) => {
   return (
     <Card>
       <CardHeader>

--- a/apps/app/src/features/dashboard/components/UserOnboardingDialog.tsx
+++ b/apps/app/src/features/dashboard/components/UserOnboardingDialog.tsx
@@ -10,8 +10,15 @@ import { PhoneNumberDialogStep } from './PhoneNumberDialogStep'
 import { useState } from 'react'
 import { CompleteOnboardingDialogStep } from './CompleteOnboardingDialogStep'
 
+export type OnboardingStep =
+  | 'welcome'
+  | 'goals-and-direction'
+  | 'phone-number'
+  | 'complete'
+  | null
+
 export interface UserOnboardingDialogStepProps {
-  setCurrentStep: (step: string | null) => void
+  setCurrentStep: (step: OnboardingStep) => void
 }
 
 interface Props {
@@ -19,7 +26,7 @@ interface Props {
 }
 
 export const UserOnboardingDialog = (props: Props) => {
-  const [currentStep, setCurrentStep] = useState<string | null>(
+  const [currentStep, setCurrentStep] = useState<OnboardingStep>(
     props.onboardingCompleted ? null : 'welcome'
   )
 

--- a/apps/app/src/features/dashboard/components/UserOnboardingDialog.tsx
+++ b/apps/app/src/features/dashboard/components/UserOnboardingDialog.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import {
+  Dialog,
+  DialogContent,
+} from '@internal/design-system/components/ui/dialog'
+import { GoalsAndDirectionDialogStep } from './GoalsAndDirectionDialogStep'
+import { WelcomeDialogStep } from './WelcomeDialogStep'
+import { PhoneNumberDialogStep } from './PhoneNumberDialogStep'
+import { useState } from 'react'
+import { CompleteOnboardingDialogStep } from './CompleteOnboardingDialogStep'
+
+export interface UserOnboardingDialogStepProps {
+  setCurrentStep: (step: string | null) => void
+}
+
+interface Props {
+  onboardingCompleted?: boolean
+}
+
+export const UserOnboardingDialog = (props: Props) => {
+  const [currentStep, setCurrentStep] = useState<string | null>(
+    props.onboardingCompleted ? null : 'welcome'
+  )
+
+  return (
+    <Dialog open={!props.onboardingCompleted && currentStep !== null}>
+      <DialogContent showCloseButton={false}>
+        {currentStep === 'welcome' ? (
+          <WelcomeDialogStep setCurrentStep={setCurrentStep} />
+        ) : null}
+        {currentStep === 'goals-and-direction' ? (
+          <GoalsAndDirectionDialogStep setCurrentStep={setCurrentStep} />
+        ) : null}
+        {currentStep === 'phone-number' ? (
+          <PhoneNumberDialogStep
+            defaultCountry="ES"
+            setCurrentStep={setCurrentStep}
+          />
+        ) : null}
+        {currentStep === 'complete' ? (
+          <CompleteOnboardingDialogStep setCurrentStep={setCurrentStep} />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/app/src/features/dashboard/components/WelcomeDialogStep.tsx
+++ b/apps/app/src/features/dashboard/components/WelcomeDialogStep.tsx
@@ -1,0 +1,35 @@
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@internal/design-system/components/ui/dialog'
+import { Button } from '@internal/design-system/components/ui/button'
+import type { UserOnboardingDialogStepProps } from './UserOnboardingDialog'
+
+export const WelcomeDialogStep = (props: UserOnboardingDialogStepProps) => {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Welcome to Inspire</DialogTitle>
+        <DialogDescription>
+          Let&#39;s set up your personalized experience.
+        </DialogDescription>
+      </DialogHeader>
+      <div className="space-y-6">
+        <p>
+          We&#39;re here to help you stay motivated and achieve your goals
+          through personalized messages.
+        </p>
+      </div>
+      <DialogFooter>
+        <Button
+          onClick={() => props.setCurrentStep('goals-and-direction')}
+          type="submit"
+        >
+          Get started
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}

--- a/apps/app/src/features/dashboard/components/index.ts
+++ b/apps/app/src/features/dashboard/components/index.ts
@@ -1,3 +1,4 @@
 export * from './ManageFrequency'
 export * from './ManageGoalsAndDirection'
 export * from './Preview'
+export * from './UserOnboardingDialog'

--- a/apps/app/src/features/dashboard/components/index.ts
+++ b/apps/app/src/features/dashboard/components/index.ts
@@ -1,4 +1,4 @@
 export * from './ManageFrequency'
 export * from './ManageGoalsAndDirection'
-export * from './Preview'
+export * from './PreviewMessage'
 export * from './UserOnboardingDialog'

--- a/apps/app/src/features/dashboard/index.ts
+++ b/apps/app/src/features/dashboard/index.ts
@@ -1,2 +1,3 @@
 export * from './api'
+export * from './components'
 export * from './templates'

--- a/apps/app/src/features/dashboard/templates/DashboardPageTemplate.tsx
+++ b/apps/app/src/features/dashboard/templates/DashboardPageTemplate.tsx
@@ -3,7 +3,7 @@
 import {
   ManageFrequency,
   ManageGoalsAndDirection,
-  Preview,
+  PreviewMessage,
 } from '../components'
 import { useQueries } from '@tanstack/react-query'
 import { getPreferencesOptions, getPreviewOptions } from '../api'
@@ -58,7 +58,7 @@ export const DashboardPageTemplate = () => {
             }
           />
           {previewQuery.isLoading ? null : (
-            <Preview
+            <PreviewMessage
               preview={{
                 message: previewQuery.data?.message ?? 'No preview available.',
               }}

--- a/apps/app/src/globals.d.ts
+++ b/apps/app/src/globals.d.ts
@@ -1,0 +1,9 @@
+export {}
+
+declare global {
+  interface CustomJwtSessionClaims {
+    metadata: {
+      onboardingCompleted?: boolean
+    }
+  }
+}

--- a/packages/agents/motivator/index.ts
+++ b/packages/agents/motivator/index.ts
@@ -1,6 +1,9 @@
 import type OpenAI from 'openai'
 import { z } from 'zod'
-import { LogItemMessage, LogItemExtraInput } from '@aws-lambda-powertools/logger/types'
+import type {
+  LogItemMessage,
+  LogItemExtraInput,
+} from '@aws-lambda-powertools/logger/types'
 
 interface LoggerInterface {
   error: (message: LogItemMessage, ...extraInput: LogItemExtraInput) => void


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

# Proposed changes

<!-- Describe the changes here giving as much context as necessary -->

This pull request introduces a comprehensive user onboarding dialog flow for the dashboard, guiding new users through a multi-step setup process. The onboarding flow includes welcome, goals and themes selection, phone number entry, and completion steps, and is automatically shown to users who have not completed onboarding. Supporting changes include new dialog components, UI integration, and export adjustments.

**User Onboarding Dialog Implementation:**

- Added a new `UserOnboardingDialog` component that manages a multi-step onboarding process (welcome, goals/themes, phone number, complete) and tracks progression using state. The dialog is shown to users who have not completed onboarding, as determined by their session metadata. [[1]](diffhunk://#diff-aa9635d269724440921048eaae02c4cd3e581073aad30a72a5da0237a37f8cc9R1-R47) [[2]](diffhunk://#diff-44b21dc58c4ef726774278821dc22847273ec5140a547a168bf15fe60acb4f10R8-R17) [[3]](diffhunk://#diff-44b21dc58c4ef726774278821dc22847273ec5140a547a168bf15fe60acb4f10R33-R35)
- Created individual step components: `WelcomeDialogStep`, `GoalsAndDirectionDialogStep`, `PhoneNumberDialogStep`, and `CompleteOnboardingDialogStep`, each handling its respective part of the onboarding flow with form validation, mutation hooks, and UI feedback. [[1]](diffhunk://#diff-eb348e8ffd66b1277af620dceb53feb339a7e6febc081398baea6529c4c77285R1-R35) [[2]](diffhunk://#diff-0d3508ce2c9489759af604b34c4b3fe788c8e509abb5c97c492954bea2d41c32R1-R172) [[3]](diffhunk://#diff-63e951f2eed7599ea383f929a0e3374e1ddfc122cf0fd88cf161ebebbf36d2f0R1-R100) [[4]](diffhunk://#diff-802fc24156f75de297604171fa800d7e273488fac5ddc624e4179c45918ab46dR1-R56)

**Integration and UI Updates:**

- Integrated `UserOnboardingDialog` into the main authenticated layout, passing onboarding completion status from the user's session. [[1]](diffhunk://#diff-44b21dc58c4ef726774278821dc22847273ec5140a547a168bf15fe60acb4f10R8-R17) [[2]](diffhunk://#diff-44b21dc58c4ef726774278821dc22847273ec5140a547a168bf15fe60acb4f10R33-R35)
- Exported new components in `index.ts` files for easier imports throughout the app. [[1]](diffhunk://#diff-e9b51f05096073517c8e3ac12315c8ac6fd5187aaf97f51e64a8ccbf62d1ea2eR4) [[2]](diffhunk://#diff-03efaea01dfebede32d68171348231c5dee8d816b474ee2c793e90858b8493f7R2)

## Related links

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Related issue #
- Closes #

## Definition of Done

<!-- Strikethrough any below that are not applicable. -->

**Always:**

- [x] All Acceptance Criteria have been met <!-- (if not, specify what's left via TODOs)  -->
- [x] Test successfully locally
- [ ] Increase or maintain coverage
